### PR TITLE
config.py 中的 DEFAULT_PORT 与 HOST 配置项的特殊处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ elimage.db
 *.bak
 .*.swp
 
-/__pycache__
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 elimage.db
 *~
 *.bak
-.*.swap
+.*.swp
 
 /__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 elimage.db
+*~
+*.bak
+.*.swap
+
+/__pycache__

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can specify multiple `-F` parameters for multiple image files. The name of
 the form field doesn't matter.
 
 ```sh
-curl -F 'name=@path/to/image' http://<your_host>/
+curl -F 'name=@path/to/image' http://<your_host>[:port]/
 ```
 
 Requirement

--- a/config.py
+++ b/config.py
@@ -1,7 +1,6 @@
 DEBUG = True
 DEFAULT_DATA_DIR = '/tmp'
 DEFAULT_PORT = 8888
-HOST = '' # override Host header, useful when behind another server
 XHEADERS = True # you may set this to false if not behind another server
 DB = 'elimage.db'
 

--- a/main.py
+++ b/main.py
@@ -5,10 +5,12 @@ from models import model
 
 import os
 import sys
+import logging
 import hashlib
 from collections import OrderedDict
 import mimetypes
 import subprocess
+
 try:
   from functools import lru_cache
 except ImportError:
@@ -71,8 +73,8 @@ class IndexHandler(BaseHandler):
           content = self.index_template.generate(url=self.request.full_url())
           self.write(content)
       except IOError as err:
+        logging.exception('index.html file: ' + str(err))
         raise tornado.web.HTTPError(404, 'index.html file is missing')
-        print('index.html file: ' + str(err))
 
   def post(self):
     # Check the user has been blocked or not
@@ -107,7 +109,7 @@ class IndexHandler(BaseHandler):
             with open(fpath, 'wb') as img_file:
               img_file.write(file['body'])
           except IOError as err: 
-            print("image file: " + str(err))
+            logging.exception("image file: " + str(err))
             continue
 
         ftype = mimetypes.guess_type(fpath)[0]
@@ -156,10 +158,10 @@ def main():
   elif idx != -1:
     port = int(host[idx+1:])
     if port != DEFAULT_PORT:
-      print("warning: DEFAULT_PORT %d is not equal host port %d, using %d" %
+      logging.warning("DEFAULT_PORT %d is not equal host port %d, using %d" %
               (DEFAULT_PORT, port, port))
 
-  define("port", default=DEFAULT_PORT, help="run on the given port", type=int)
+  define("port", default=port, help="run on the given port", type=int)
   define("datadir", default=DEFAULT_DATA_DIR, help="the directory to put uploaded data", type=str)
   define("fork", default=False, help="fork after startup", type=bool)
 

--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ class IndexHandler(tornado.web.RequestHandler):
               img_file.write(file['body'])
           except IOError: 
             logging.exception('failed to open the file: %s', fpath)
-            self.write('failed to upload the file: %s\n' % fpath)
+            self.write('failed to upload the file: %s\n' % file['filename'])
             ret[file['filename']] = 'fail'
             continue
 
@@ -118,9 +118,11 @@ class IndexHandler(tornado.web.RequestHandler):
           ret[file['filename']] = '%s/%s/%s' % (
                   self.request.full_url().rstrip('/'), d, f)
 
-    if ret:
+    if len(ret) > 1:
       for item in ret.items():
         self.write('%s: %s\n' % item)
+    elif ret:
+      self.write("%s\n" % tuple(ret.values())[0])
 
 class ToolHandler(tornado.web.RequestHandler):
   def get(self):

--- a/main.py
+++ b/main.py
@@ -103,7 +103,12 @@ class IndexHandler(BaseHandler):
           os.mkdir(p, 0o750)
         fpath = os.path.join(p, f)
         if not os.path.exists(fpath):
-          open(fpath, 'wb').write(file['body'])
+          try:
+            with open(fpath, 'wb') as img_file:
+              img_file.write(file['body'])
+          except IOError as err: 
+            print("image file: " + str(err))
+            continue
 
         ftype = mimetypes.guess_type(fpath)[0]
         ext = None

--- a/main.py
+++ b/main.py
@@ -147,6 +147,18 @@ class HashHandler(BaseHandler):
 def main():
   import tornado.httpserver
   from tornado.options import define, options
+
+  host = HOST
+  port = DEFAULT_PORT
+  idx = host.find(':')
+  if DEFAULT_PORT != 80 and idx == -1:
+    host += ':' + str(DEFAULT_PORT)
+  elif idx != -1:
+    port = int(host[idx+1:])
+    if port != DEFAULT_PORT:
+      print("warning: DEFAULT_PORT %d is not equal host port %d, using %d" %
+              (DEFAULT_PORT, port, port))
+
   define("port", default=DEFAULT_PORT, help="run on the given port", type=int)
   define("datadir", default=DEFAULT_DATA_DIR, help="the directory to put uploaded data", type=str)
   define("fork", default=False, help="fork after startup", type=bool)
@@ -155,10 +167,6 @@ def main():
   if options.fork:
     if os.fork():
       sys.exit()
-
-  host = HOST
-  if DEFAULT_PORT!= 80 and host.find(':') == -1:
-      host += ':' + str(DEFAULT_PORT)
 
   application = tornado.web.Application([
     (r"/", IndexHandler),

--- a/main.py
+++ b/main.py
@@ -54,15 +54,7 @@ def guess_extension(ftype):
     ext = '.jpg'
   return ext
 
-class BaseHandler(tornado.web.RequestHandler):
-  def initialize(self):
-    try:
-      if self.settings['host']:
-        self.request.host = self.settings['host']
-    except KeyError:
-      pass
-
-class IndexHandler(BaseHandler):
+class IndexHandler(tornado.web.RequestHandler):
   index_template = None
   def get(self):
     # self.render() would compress whitespace after it meets '{{' even in <pre>
@@ -130,12 +122,12 @@ class IndexHandler(BaseHandler):
       for item in ret.items():
         self.write('%s: %s\n' % item)
 
-class ToolHandler(BaseHandler):
+class ToolHandler(tornado.web.RequestHandler):
   def get(self):
     self.set_header('Content-Type', 'text/x-python')
     self.render('elimage', url=self.request.full_url()[:-len(SCRIPT_PATH)])
 
-class HashHandler(BaseHandler):
+class HashHandler(tornado.web.RequestHandler):
   def get(self, p):
     if '.' in p:
       h, ext = p.split('.', 1)

--- a/main.py
+++ b/main.py
@@ -156,6 +156,10 @@ def main():
     if os.fork():
       sys.exit()
 
+  host = HOST
+  if DEFAULT_PORT!= 80 and host.find(':') == -1:
+      host += ':' + str(DEFAULT_PORT)
+
   application = tornado.web.Application([
     (r"/", IndexHandler),
     (r"/" + SCRIPT_PATH, ToolHandler),
@@ -164,7 +168,7 @@ def main():
     }),
     (r"/([a-fA-F0-9/]+(?:\.\w*)?)", HashHandler),
   ],
-    host=HOST,
+    host=host,
     datadir=options.datadir,
     debug=DEBUG,
     template_path=os.path.join(os.path.dirname(__file__), "templates"),

--- a/main.py
+++ b/main.py
@@ -105,8 +105,7 @@ class IndexHandler(tornado.web.RequestHandler):
               img_file.write(file['body'])
           except IOError: 
             logging.exception('failed to open the file: %s', fpath)
-            self.write('failed to upload the file: %s\n' % file['filename'])
-            ret[file['filename']] = 'fail'
+            ret[file['filename']] = 'FAIL'
             continue
 
         ftype = mimetypes.guess_type(fpath)[0]
@@ -121,8 +120,13 @@ class IndexHandler(tornado.web.RequestHandler):
     if len(ret) > 1:
       for item in ret.items():
         self.write('%s: %s\n' % item)
+        if item[1] == "FAIL":
+          self.set_status(500)
     elif ret:
-      self.write("%s\n" % tuple(ret.values())[0])
+      img_url = tuple(ret.values())[0]
+      self.write("%s\n" % img_url)
+      if img_url == "FAIL":
+        self.set_status(500)
 
 class ToolHandler(tornado.web.RequestHandler):
   def get(self):

--- a/main.py
+++ b/main.py
@@ -62,12 +62,17 @@ class IndexHandler(BaseHandler):
   def get(self):
     # self.render() would compress whitespace after it meets '{{' even in <pre>
     if self.index_template is None:
-      self.index_template = tornado.template.Template(
-        open(os.path.join(self.settings['template_path'], 'index.html'), 'r').read(),
-        compress_whitespace=False,
-      )
-    content = self.index_template.generate(url=self.request.full_url())
-    self.write(content)
+      try:
+        file_name = os.path.join(self.settings['template_path'], 'index.html')
+        with open(file_name, 'r') as index_file:
+          text = index_file.read()
+          self.index_template = tornado.template.Template(text,
+                  compress_whitespace=False)
+          content = self.index_template.generate(url=self.request.full_url())
+          self.write(content)
+      except IOError as err:
+        raise tornado.web.HTTPError(404, 'index.html file is missing')
+        print('index.html file: ' + str(err))
 
   def post(self):
     # Check the user has been blocked or not


### PR DESCRIPTION
1. 如果 DEFAULT_PORT 不是 80，那么返回给 curl 的链接里也没有加上端口号。
   例如:
   DEFAULT_PORT = 8080
   HOST = http://localhost
   curl -F "name=@foobar.png" http://localhost:8080/
   http://localhost/80/a75ecfa2299110eeb2667f7bcee645405174ef.png

2. 判断 DEFAULT_PORT 是否与 HOST 中的 port 一致。如果不一致则使用 HOST 中的 port.
    例如:
    DEFAULT_PORT = 3333
    HOST = http://localhost:8080
    使用 8080 作为 define("host", default=8080, ...) 的参数。
