### PR TITLE
portable `file` mime option

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ def guess_mime_using_file_p(path):
 
 def guess_mime_using_file(content):
   result = subprocess.check_output(
-    ['file', '-i', '-'],
+    ['file', '--mime', '-'],
     input = content,
   ).decode()
   _, mime, encoding = result.split()


### PR DESCRIPTION
On macOS `-I` is used to check for MIME type, where on GNU/Linux it is `-i`. Both supports `--mime` and it is clearer what is happening.